### PR TITLE
NTP choice & mandatory Spot VM

### DIFF
--- a/Tools/ASDKscripts/ASDKAzureVMTemplate.json
+++ b/Tools/ASDKscripts/ASDKAzureVMTemplate.json
@@ -105,7 +105,7 @@
 		"AADUserName": {
 			"type": "string",
 			"metadata": {
-				"description": "Password of the Azure Directory, please provide while DeploymentType is AAD"
+				"description": "UserName of the Azure Directory, please provide while DeploymentType is AAD - user@yourtenant.onmicrosoft.com"
 			}
 		},
 		"AADPassword": {
@@ -125,6 +125,13 @@
 			"metadata": {
 				"description": "ASDK deployment type"
 			}
+		},
+		"TimeServerIP": {
+			"type": "string",
+			"metadata": {
+				"description": "NTP IP, if NTP service is down or IP unreachable, ASDK install will fail"
+			},
+			"defaultValue": "13.86.101.172"
 		}
 	},
 	"variables": {
@@ -258,6 +265,11 @@
 				"[resourceId('Microsoft.Compute/images/', variables('imageName'))]"
 			],
 			"properties": {
+				"priority": "Spot",
+                "evictionPolicy": "Deallocate",
+                "billingProfile": {
+                    "maxPrice": -1
+                },
 				"hardwareProfile": {
 					"vmSize": "[parameters('vmSize')]"
 				},
@@ -324,7 +336,7 @@
 							"fileUris": [
 								"[variables('extensionFileLocation')]"
 							],
-							"commandToExecute": "[concat('powershell.exe -File Invoke-ASDKDeployment.ps1 -AdminUsername ', parameters('adminUsername'), ' -AdminPassword ', parameters('adminPassword'), ' -AzureDirectoryTenantName ', parameters('AzureDirectoryTenantName'), ' -AADUsername ', parameters('AADUsername'), ' -AADPassword ',variables('doubleQuote') , parameters('AADPassword'), variables('doubleQuote') ,' -DeploymentType ', parameters('DeploymentType'))]"
+							"commandToExecute": "[concat('powershell.exe -File Invoke-ASDKDeployment.ps1 -AdminUsername ', parameters('adminUsername'), ' -AdminPassword ', parameters('adminPassword'), ' -TimeServerIP ', parameters('TimeServerIP'), ' -AzureDirectoryTenantName ', parameters('AzureDirectoryTenantName'), ' -AADUsername ', parameters('AADUsername'), ' -AADPassword ',variables('doubleQuote') , parameters('AADPassword'), variables('doubleQuote') ,' -DeploymentType ', parameters('DeploymentType'))]"
 						}
 					}
 				}


### PR DESCRIPTION

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
Original hardcoded NTP IP 13.86.101.172 was offline and therefore broke Stack deployment at very beginning of initial deployment. Added a parameter method to template to allow bypassing / providing alternate NTP server. Mandated VM be Spot VM to greatly reduce cost of deploying ASDK

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
Try deployment with unreachable or bad NTP IP address, then try with a working NTP IP
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->